### PR TITLE
Updating the Rtcomm protocol version to v1.0.0 for third party control

### DIFF
--- a/lib/3pcc.js
+++ b/lib/3pcc.js
@@ -161,7 +161,7 @@ function ThirdPartyCC(config, resultCallback) {
 		
 		l('DEBUG') && console.log('ThirdPartyCC: start call between: caller: '+callerEndpointID+' and callee: '+calleeEndpointID+' topic: '+this.config.topic);
 		var message = {
-			'rtcommVer' : 'v0.0.1',
+			'rtcommVer' : 'v1.0.0',
 			'method' : '3PCC_PLACE_CALL',
 			'calleeEndpoint' : calleeEndpointID,
 			'callerEndpoint' : callerEndpointID,


### PR DESCRIPTION
This needed to be done in order for third party call control could work. 